### PR TITLE
Adopt Computer Modern font stack for site typography

### DIFF
--- a/code.html
+++ b/code.html
@@ -21,10 +21,10 @@
 <link rel="alternate" href="/atom.xml" title="Hanfeng Zhai" type="application/atom+xml">
 <link rel="icon" href="/css/images/avatar.jpg">
 <link rel="apple-touch-icon" href="/css/images/avatar.jpg">
-<link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
-  
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans|Montserrat:700" rel="stylesheet" type="text/css">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-serif.css" rel="stylesheet" type="text/css">
+
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-sans.css" rel="stylesheet" type="text/css">
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-typewriter.css" rel="stylesheet" type="text/css">
   <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
   <style type="text/css">
 }

--- a/css/archive.css
+++ b/css/archive.css
@@ -4,7 +4,7 @@ h1 {
     margin-bottom: 8px;
 }
 h1>a {
-        font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+        font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
 }
 .wrapper,.copyright {
 	padding: 10px;

--- a/css/dialog.css
+++ b/css/dialog.css
@@ -12,7 +12,7 @@
 }*/
 .modal-title {
         color: #000;
-    font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+    font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
     text-align: center;
     font-weight: bold;
 }
@@ -53,6 +53,6 @@
 	padding-bottom: 80px;
 }
 .panel-body {
-        font-family: 'Latin Modern Mono', 'Latin Modern Mono Light', 'Courier New', Courier, monospace;
+        font-family: 'Computer Modern Typewriter', 'Latin Modern Mono', 'Courier New', Courier, monospace;
         color:#333;
 }

--- a/css/header-post.css
+++ b/css/header-post.css
@@ -4,7 +4,7 @@
         display: block;
         float: right;
         margin: 20px 0 0 0;
-        font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+        font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
         font-size: 16px;
         font-weight: 100;
         letter-spacing: .1px;

--- a/css/home.css
+++ b/css/home.css
@@ -89,7 +89,7 @@ html{
     transition: background 2s;
 }
 .navigater-list{
-        font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+        font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
         color:#444444;
         font-weight: 100;
         font-size: 1.2em;
@@ -196,14 +196,14 @@ body, html {
 	text-align: center;
 }
 h1 {
-    font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+    font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
     font-weight: bold;
     font-size: 25px;
     margin: 12px 0;
     left: 4px;
 }
 h3 {
-        font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+        font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
     font-weight: normal;
     font-size: 20px;
     margin-bottom: 30px;
@@ -274,7 +274,7 @@ hr{
 }
  
 #beautifont{
-        font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+        font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
 }
 canvas {
     top: 0;

--- a/css/style.css
+++ b/css/style.css
@@ -113,14 +113,83 @@ button::-moz-focus-inner {
   border: 0;
   padding: 0;
 }
-@import url('https://fonts.cdnfonts.com/css/latin-modern-roman');
-@import url('https://fonts.cdnfonts.com/css/latin-modern-mono');
+@font-face {
+  font-family: 'Computer Modern Serif';
+  font-style: normal;
+  font-weight: 400;
+  src: url('https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/fonts/cmunrm.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Computer Modern Serif';
+  font-style: italic;
+  font-weight: 400;
+  src: url('https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/fonts/cmunti.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Computer Modern Serif';
+  font-style: normal;
+  font-weight: 700;
+  src: url('https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/fonts/cmunbx.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Computer Modern Serif';
+  font-style: italic;
+  font-weight: 700;
+  src: url('https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/fonts/cmunbi.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Computer Modern Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: url('https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/fonts/cmunss.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Computer Modern Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: url('https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/fonts/cmunsi.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Computer Modern Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: url('https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/fonts/cmunsx.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Computer Modern Typewriter';
+  font-style: normal;
+  font-weight: 400;
+  src: url('https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/fonts/cmuntt.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Computer Modern Typewriter';
+  font-style: italic;
+  font-weight: 400;
+  src: url('https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/fonts/cmunit.woff') format('woff');
+  font-display: swap;
+}
 html,
 body,
 body {
   background: none;
   font-size: 15px;
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
   -webkit-text-size-adjust: 100%;
   text-rendering: optimizeLegibility;
 }
@@ -138,13 +207,13 @@ body,
 .navigater-list > a,
 #header,
 #header a {
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
 }
 
 code,
 pre,
 tt {
-  font-family: 'Latin Modern Mono', 'Latin Modern Mono Light', 'Courier New', Courier, monospace;
+  font-family: 'Computer Modern Typewriter', 'Latin Modern Mono', 'Courier New', Courier, monospace;
 }
 ::selection {
   background: #414141;
@@ -627,7 +696,7 @@ tt {
   height: 88px;
   line-height: 86px;
   text-transform: capitalize;
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
   font-weight: bold;
   font-size: 27px;
   letter-spacing: 0.2px;
@@ -702,7 +771,7 @@ tt {
   outline: none !important;
   background: none !important;
   font-size: 14px;
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
   border: 0px;
 }
 .search-form-input:focus,
@@ -772,7 +841,7 @@ tt {
 .article-inner .h4,
 .article-inner .h5,
 .article-inner .h6 {
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
 }
 .article-meta {
   text-align: center;
@@ -901,7 +970,7 @@ tt {
 .article-header h1 {
   font-size: 25px;
   font-weight: bold;
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
 }
 @media screen and (max-width: 479px) {
   .article-header h1 {
@@ -1015,7 +1084,7 @@ a.article-title:hover {
 }
 .article-entry blockquote {
   padding: 0.1px 20px;
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
   font-size: 1.1em;
   color: rgba(44,44,44,0.6);
   margin: 1.4em 0px;
@@ -1029,7 +1098,7 @@ a.article-title:hover {
 .article-entry blockquote footer {
   font-size: 14px;
   margin: 1.6em 0;
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
 }
 .article-entry blockquote footer cite:before {
   content: "—";
@@ -1051,7 +1120,7 @@ a.article-title:hover {
   }
 }
 .article-entry .pullquote p {
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
   font-size: 1.2em;
 }
 .article-entry .pullquote:before {
@@ -1277,7 +1346,7 @@ a.article-title:hover {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   font-size: 15px;
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
   padding: 0 15px;
   color: #444;
   outline: none;
@@ -1461,7 +1530,7 @@ a.article-title:hover {
   color: #414141;
 }
 .nav-link {
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
   color: #777;
   padding: 1px !important;
 }
@@ -1673,7 +1742,7 @@ a.article-title:hover {
   margin-right: 15px;
   display: block;
   font-size: 1.1em;
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
 }
 .archive-article-date:hover {
   color: #414141;
@@ -1812,7 +1881,7 @@ figure.highlight::-webkit-scrollbar-track {
 }
 .article-entry pre,
 .article-entry code {
-  font-family: 'Latin Modern Mono', 'Latin Modern Mono Light', 'Courier New', Courier, monospace;
+  font-family: 'Computer Modern Typewriter', 'Latin Modern Mono', 'Courier New', Courier, monospace;
 }
 .article-entry code {
   white-space: normal;
@@ -1886,7 +1955,7 @@ figure.highlight::-webkit-scrollbar-track {
 }
 .article-entry .gist .gist-file {
   border: none;
-  font-family: 'Latin Modern Mono', 'Latin Modern Mono Light', 'Courier New', Courier, monospace;
+  font-family: 'Computer Modern Typewriter', 'Latin Modern Mono', 'Courier New', Courier, monospace;
   margin: 0;
 }
 .article-entry .gist .gist-file .gist-data {
@@ -1910,7 +1979,7 @@ figure.highlight::-webkit-scrollbar-track {
   background: #f8f8f8;
   color: $highlight-comment;
   font-size: 0.85em;
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
   text-shadow: 0 0;
   padding: 0;
   margin-top: 1em;
@@ -2126,7 +2195,7 @@ pre .xml .cdata {
   box-sizing: border-box;
   padding: 12px 28px 12px 20px;
   border-bottom: 1px solid #e2e2e2;
-  font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+  font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
 }
 .ins-close {
   top: 50%;

--- a/gallery.html
+++ b/gallery.html
@@ -22,9 +22,9 @@
 
 <link rel="icon" href="/css/images/avatar.jpg">
 <link rel="apple-touch-icon" href="/css/images/avatar.jpg">
-<link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans|Montserrat:700" rel="stylesheet" type="text/css">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-serif.css" rel="stylesheet" type="text/css">
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-sans.css" rel="stylesheet" type="text/css">
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-typewriter.css" rel="stylesheet" type="text/css">
   <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
   <style type="text/css">
 }

--- a/index.html
+++ b/index.html
@@ -23,11 +23,9 @@
 <link rel="alternate" href="/atom.xml" title="Hanfeng Zhai" type="application/atom+xml">
   <link rel="icon" href="/css/images/avatar.jpg">
   <link rel="apple-touch-icon" href="/css/images/avatar.jpg">
-  <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans|Montserrat:700" rel="stylesheet" type="text/css">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic" rel="stylesheet" type="text/css">
-  <link href="https://fonts.cdnfonts.com/css/latin-modern-roman" rel="stylesheet" type="text/css">
-  <link href="https://fonts.cdnfonts.com/css/latin-modern-mono" rel="stylesheet" type="text/css">
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-serif.css" rel="stylesheet" type="text/css">
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-sans.css" rel="stylesheet" type="text/css">
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-typewriter.css" rel="stylesheet" type="text/css">
   <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
   <style type="text/css">
 }
@@ -44,20 +42,20 @@
   .article-entry em,
   .article-entry a,
   .article-entry blockquote {
-    font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+    font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
   }
 
   .navigater-list,
   .navigater-list > a,
   #header,
   #header a {
-    font-family: 'Latin Modern Roman', 'Computer Modern Roman', 'Times New Roman', Times, serif;
+    font-family: 'Computer Modern Serif', 'Latin Modern Roman', 'Times New Roman', Times, serif;
   }
 
   code,
   pre,
   tt {
-    font-family: 'Latin Modern Mono', 'Latin Modern Mono Light', 'Courier New', Courier, monospace;
+    font-family: 'Computer Modern Typewriter', 'Latin Modern Mono', 'Courier New', Courier, monospace;
   }
 </style>
 <script src="/js/jquery-3.1.1.min.js"></script>

--- a/note.html
+++ b/note.html
@@ -16,7 +16,9 @@
     <link rel="alternate" href="/atom.xml" title="Hanfeng Zhai" type="application/atom+xml">
     <link rel="icon" href="/css/images/avatar.jpg">
     <link rel="apple-touch-icon" href="/css/images/avatar.jpg">
-    <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro|Open+Sans|Montserrat:700|Roboto:400,300,300italic,400italic" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-serif.css" rel="stylesheet" type="text/css">
+    <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-sans.css" rel="stylesheet" type="text/css">
+    <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-typewriter.css" rel="stylesheet" type="text/css">
     <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="/css/bootstrap.css">

--- a/research.html
+++ b/research.html
@@ -18,9 +18,9 @@
 <link rel="alternate" href="/atom.xml" title="Hanfeng Zhai" type="application/atom+xml">
   <link rel="icon" href="/css/images/avatar.jpg">
   <link rel="apple-touch-icon" href="/css/images/avatar.jpg">
-  <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans|Montserrat:700" rel="stylesheet" type="text/css">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic" rel="stylesheet" type="text/css">
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-serif.css" rel="stylesheet" type="text/css">
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-sans.css" rel="stylesheet" type="text/css">
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-typewriter.css" rel="stylesheet" type="text/css">
   <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
   <style type="text/css">
 }

--- a/talk.html
+++ b/talk.html
@@ -22,10 +22,10 @@
 <link rel="alternate" href="/atom.xml" title="Hanfeng Zhai" type="application/atom+xml">
 <link rel="icon" href="/css/images/avatar.jpg">
 <link rel="apple-touch-icon" href="/css/images/avatar.jpg">
-<link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-serif.css" rel="stylesheet" type="text/css">
 
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans|Montserrat:700" rel="stylesheet" type="text/css">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic" rel="stylesheet" type="text/css">
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-sans.css" rel="stylesheet" type="text/css">
+  <link href="https://cdn.jsdelivr.net/npm/computer-modern-web-font@1.0.0/css/cmun-typewriter.css" rel="stylesheet" type="text/css">
   <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
   <style type="text/css">
 }


### PR DESCRIPTION
## Summary
- add Computer Modern @font-face declarations and update the global font stack to use them site-wide
- replace prior Google/Latin Modern font includes with Computer Modern CDN stylesheets across top-level pages

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68efbd631630832e827e0ddd8b26bd1d