### PR TITLE
Replace Latin Modern Roman oblique faces with italic variants

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -141,7 +141,7 @@ button::-moz-focus-inner {
   font-family: 'Latin Modern Roman';
   font-style: italic;
   font-weight: 600;
-  src: url('../assets/fonts/latin-modern-roman/lmromandemi10-oblique.otf') format('opentype');
+  src: url('../assets/fonts/latin-modern-roman/lmroman10-italic.otf') format('opentype');
   font-display: swap;
 }
 
@@ -161,13 +161,6 @@ button::-moz-focus-inner {
   font-display: swap;
 }
 
-@font-face {
-  font-family: 'Latin Modern Roman';
-  font-style: oblique;
-  font-weight: 400;
-  src: url('../assets/fonts/latin-modern-roman/lmromanslant10-regular.otf') format('opentype');
-  font-display: swap;
-}
 html,
 body,
 body {


### PR DESCRIPTION
## Summary
- update the Latin Modern Roman 600-weight font-face to reference the italic file instead of the oblique version
- remove the extra font-face that mapped the slanted variant so only italic styling is used for tilted text

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68f062c72b10832eb9986baedc204278