### PR TITLE
Adjust timeline font sizes to match biography text

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -207,13 +207,13 @@ body, html {
 
 .timeline-content {
         padding: 20px;
-        font-size: 0.95rem;
+        font-size: 1rem;
         line-height: 1.5;
         color: #333333;
 }
 
 .timeline-year {
-        font-size: 1.1rem;
+        font-size: 1rem;
         font-weight: 600;
         color: #1a4d8f;
         margin-bottom: 10px;


### PR DESCRIPTION
## Summary
- update the timeline scroll card content and year text to use the same base font size as the biography section

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68f959c409b4832e8ae153f76b4620bc