### PR TITLE
Increase timeline font sizes

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -207,13 +207,13 @@ body, html {
 
 .timeline-content {
         padding: 20px;
-        font-size: 0.95rem;
+        font-size: 1.125rem;
         line-height: 1.5;
         color: #333333;
 }
 
 .timeline-year {
-        font-size: 1.1rem;
+        font-size: 1.25rem;
         font-weight: 600;
         color: #1a4d8f;
         margin-bottom: 10px;


### PR DESCRIPTION
## Summary
- enlarge the timeline card body text to 1.125rem for improved readability
- raise the year label size to 1.25rem so it stands out in the scroll bar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f959c409b4832e8ae153f76b4620bc