### PR TITLE
Increase timeline font size

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -207,13 +207,13 @@ body, html {
 
 .timeline-content {
         padding: 20px;
-        font-size: 3.6rem;
+        font-size: 2rem;
         line-height: 1.5;
         color: #333333;
 }
 
 .timeline-year {
-        font-size: 3.6rem;
+        font-size: 2rem;
         font-weight: 600;
         color: #1a4d8f;
         margin-bottom: 10px;

--- a/css/home.css
+++ b/css/home.css
@@ -207,13 +207,13 @@ body, html {
 
 .timeline-content {
         padding: 20px;
-        font-size: 1rem;
+        font-size: 3.6rem;
         line-height: 1.5;
         color: #333333;
 }
 
 .timeline-year {
-        font-size: 1rem;
+        font-size: 3.6rem;
         font-weight: 600;
         color: #1a4d8f;
         margin-bottom: 10px;


### PR DESCRIPTION
## Summary
- increase the timeline card content and year font size to 3.6rem as requested

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f961901454832e8ee8e9057fa3d8fa