### PR TITLE
Convert gallery highlights to scrollable cards

### DIFF
--- a/css/archive.css
+++ b/css/archive.css
@@ -81,5 +81,98 @@ hr{
 .social-icons .fa-google-plus,.social-icons .fa-google-plus-square{background-color:#000000;} 
 .social-icons .fa-instagram{background-color:#000000;}
 .social-icons .fa-linkedin,.social-icons .fa-linkedin-square{background-color:#000000;} 
-.social-icons .fa-twitter,.social-icons .fa-twitter-square{background-color:#000000;} 
+.social-icons .fa-twitter,.social-icons .fa-twitter-square{background-color:#000000;}
 .social-icons .fa-youtube,.social-icons .fa-youtube-play,.social-icons .fa-youtube-square{background-color:#000000;}
+
+.scrolling-gallery {
+        margin: 30px 0;
+}
+
+.scrolling-track {
+        display: flex;
+        gap: 20px;
+        overflow-x: auto;
+        padding: 10px 5px 20px;
+        scroll-snap-type: x mandatory;
+        -webkit-overflow-scrolling: touch;
+}
+
+.scrolling-track::-webkit-scrollbar {
+        height: 8px;
+}
+
+.scrolling-track::-webkit-scrollbar-thumb {
+        background: #c5c5c5;
+        border-radius: 4px;
+}
+
+.scrolling-card {
+        flex: 0 0 260px;
+        border: 1px solid #dcdcdc;
+        border-radius: 10px;
+        background-color: #ffffff;
+        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.05);
+        overflow: hidden;
+        scroll-snap-align: start;
+        display: flex;
+        flex-direction: column;
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+        text-align: center;
+}
+
+.scrolling-card:hover,
+.scrolling-card:focus-within {
+        transform: translateY(-4px);
+        box-shadow: 0 16px 30px rgba(0, 0, 0, 0.12);
+}
+
+.scrolling-card figure {
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+}
+
+.scrolling-card img {
+        width: 100%;
+        height: auto;
+        object-fit: cover;
+        display: block;
+}
+
+.scrolling-caption {
+        padding: 12px 14px 16px;
+        font-size: 1.4rem;
+        line-height: 1.5;
+        color: #333333;
+}
+
+.scrolling-caption strong {
+        display: block;
+        font-size: 1.5rem;
+        margin-bottom: 6px;
+}
+
+.scrolling-links {
+        margin-top: 10px;
+        display: flex;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 10px;
+        font-size: 1.3rem;
+}
+
+.scrolling-links a {
+        color: #1a4d8f;
+}
+
+.scrolling-links a:hover,
+.scrolling-links a:focus {
+        text-decoration: underline;
+}
+
+@media (max-width: 600px) {
+        .scrolling-card {
+                flex-basis: 220px;
+        }
+}

--- a/gallery.html
+++ b/gallery.html
@@ -161,42 +161,157 @@
 
 <h1 id="Research-Projects"><a href="#Research-Projects" class="headerlink" title="Research Projects"></a>Professors & Scholars</h1>
 
-<table border="1" width="100%">
-    <tr>
-        <td width="30%"><center><img src="/assets/img/profs_yeo_warner.jpg" height="300" width="265" >Profs. <a target="_blank" rel="noopener" href="https://www.engineering.cornell.edu/faculty-directory/derek-h-warner">Derek Warner</a> & <a target="_blank" rel="noopener" href="https://www.mae.cornell.edu/faculty-directory/jingjie-yeo">JJ Yeo</a></center></td>
-        <td width="30%"><center><img src="/assets/img/prof_herbert_hui.jpg" height="300" width="200" >Prof. <a target="_blank" rel="noopener" href="https://www.engineering.cornell.edu/faculty-directory/herbert-hui">Herbert Hui</a></center></td>
-        <td width="30%"><center><img src="/assets/img/prof_chris_earls.jpg" height="300" width="200" >Prof. <a target="_blank" rel="noopener" href="https://www.engineering.cornell.edu/faculty-directory/christopher-j-earls">Chris Earls</a></center></td>
-  </tr>
-</table>
+<div class="scrolling-gallery" role="region" aria-label="Professors and scholars">
+  <div class="scrolling-track">
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/profs_yeo_warner.jpg" alt="Professors Derek Warner and JJ Yeo" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Derek Warner &amp; JJ Yeo</strong>
+          Mentors who encouraged me to pursue computational mechanics and materials modeling with curiosity.
+          <div class="scrolling-links">
+            <a target="_blank" rel="noopener" href="https://www.engineering.cornell.edu/faculty-directory/derek-h-warner">Derek Warner</a>
+            <a target="_blank" rel="noopener" href="https://www.mae.cornell.edu/faculty-directory/jingjie-yeo">JJ Yeo</a>
+          </div>
+        </figcaption>
+      </figure>
+    </article>
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/prof_herbert_hui.jpg" alt="Professor Herbert Hui" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Herbert Hui</strong>
+          Taught me to appreciate the elegance of soft materials and experimental mechanics.
+          <div class="scrolling-links">
+            <a target="_blank" rel="noopener" href="https://www.engineering.cornell.edu/faculty-directory/herbert-hui">Faculty page</a>
+          </div>
+        </figcaption>
+      </figure>
+    </article>
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/prof_chris_earls.jpg" alt="Professor Chris Earls" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Chris Earls</strong>
+          Inspired my interest in optimization and uncertainty quantification for engineered systems.
+          <div class="scrolling-links">
+            <a target="_blank" rel="noopener" href="https://www.engineering.cornell.edu/faculty-directory/christopher-j-earls">Faculty page</a>
+          </div>
+        </figcaption>
+      </figure>
+    </article>
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/prof_nikolaos_bouklas.jpg" alt="Professor Nikolaos Bouklas" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Nikolaos Bouklas</strong>
+          Shared deep insights on nonlinear mechanics and the beauty of multi-scale modeling.
+          <div class="scrolling-links">
+            <a target="_blank" rel="noopener" href="https://www.engineering.cornell.edu/faculty-directory/nikolaos-bouklas">Faculty page</a>
+          </div>
+        </figcaption>
+      </figure>
+    </article>
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/prof_jan_fuhg.jpg" alt="Professor Jan Fuhg" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Jan Fuhg</strong>
+          Encouraged me to blend machine learning with mechanics for forward-looking research.
+          <div class="scrolling-links">
+            <a target="_blank" rel="noopener" href="https://fuhgjan.github.io/academic/">Academic page</a>
+          </div>
+        </figcaption>
+      </figure>
+    </article>
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/prof_david_erickson.jpg" alt="Professor David Erickson" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>David Erickson</strong>
+          Showed me how microscale physics can translate into impactful bioengineering solutions.
+          <div class="scrolling-links">
+            <a target="_blank" rel="noopener" href="https://www.engineering.cornell.edu/faculty-directory/david-erickson">Faculty page</a>
+          </div>
+        </figcaption>
+      </figure>
+    </article>
+  </div>
+</div>
 
-<table border="1" width="100%">
-    <tr>
-        <td width="30%"><center><img src="/assets/img/prof_nikolaos_bouklas.jpg" height="300" width="210" >Prof. <a target="_blank" rel="noopener" href="https://www.engineering.cornell.edu/faculty-directory/nikolaos-bouklas">Nikolaos Bouklas</a></center></td>
-        <td width="30%"><center><img src="/assets/img/prof_jan_fuhg.jpg" height="300" width="200" >Prof. <a target="_blank" rel="noopener" href="https://fuhgjan.github.io/academic/">Jan Fuhg</a></center></td>
-        <td width="30%"><center><img src="/assets/img/prof_david_erickson.jpg" height="300" width="210" >Prof. <a target="_blank" rel="noopener" href="https://www.engineering.cornell.edu/faculty-directory/david-erickson">David Erickson</a></center></td>
-  </tr>
-</table>
-		
 <h1 id="Research-Projects"><a href="#Research-Projects" class="headerlink" title="Research Projects"></a>Fun Stuff</h1>
 
-<table border="1" width="100%">
-    <tr>
-        <td width="25%"><center><img src="/assets/img/art1.JPG" height="350" width="300" ></center></td>
-        <td width="25%"><center><img src="/assets/img/art2.JPG" height="350" width="300" ></center></td>
-        <td width="20%"><center><img src="/assets/img/art3.JPG" height="350" width="300" ></center></td>
-	<td width="20%"><center><img src="/assets/img/art4.JPG" height="350" width="300" ></center></td>
-  </tr>
-</table>
-<p><center>Some paintings, Chinese calligraphy, and art stuff.</center></p>	
-<table border="1" width="100%">
-    <tr>
-        <td width="30%"><center><img src="/assets/img/afb1.JPG" height="350" width="320" ></center></td>
-        <td width="30%"><center><img src="/assets/img/afb2.JPG" height="350" width="320" ></center></td>
-        <td width="30%"><center><img src="/assets/img/afb3.JPG" height="350" width="320" ></center></td>
-  </tr>
-</table>
+<div class="scrolling-gallery" role="region" aria-label="Fun hobbies and activities">
+  <div class="scrolling-track">
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/art1.JPG" alt="Ink and watercolor painting" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Studio sketchbook</strong>
+          Weekend brushwork practice capturing warm afternoon light on campus rooftops.
+        </figcaption>
+      </figure>
+    </article>
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/art2.JPG" alt="Calligraphy practice piece" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Calligraphy meditation</strong>
+          Layered ink strokes tracing excerpts from a favorite Tang poem.
+        </figcaption>
+      </figure>
+    </article>
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/art3.JPG" alt="Figure sketch with ink wash" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Ink wash figure</strong>
+          Quick anatomy study exploring motion through fluid grayscale washes.
+        </figcaption>
+      </figure>
+    </article>
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/art4.JPG" alt="Watercolor landscape" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Mountain morning</strong>
+          Watercolor landscape inspired by a misty sunrise over the Santa Cruz hills.
+        </figcaption>
+      </figure>
+    </article>
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/afb1.JPG" alt="American football team photo" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Defensive line squad</strong>
+          Post-game snapshot with the defensive front after a close-fought win.
+        </figcaption>
+      </figure>
+    </article>
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/afb2.JPG" alt="Football action shot" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Edge rush</strong>
+          Frozen frame from a blitz drill, reading the snap and bending around the tackle.
+        </figcaption>
+      </figure>
+    </article>
+    <article class="scrolling-card">
+      <figure>
+        <img src="/assets/img/afb3.JPG" alt="Football practice huddle" loading="lazy">
+        <figcaption class="scrolling-caption">
+          <strong>Linebacker huddle</strong>
+          Quick sideline adjustment with the linebacking crew before the next series.
+        </figcaption>
+      </figure>
+    </article>
+  </div>
+</div>
 
-<p><center>I played as a DE and OLB during my undergrad. Luckily I didn't break any bones (If fingers don't count).</center></p>
+<p style="text-align:center;">Some paintings, Chinese calligraphy, art projects, and football memories.</p>
+
+<p style="text-align:center;">I played as a DE and OLB during my undergrad. Luckily I didn't break any bones (if fingers don't count).</p>
 
 <font size=2.5, color="black">
 </article>


### PR DESCRIPTION
## Summary
- replace table-based layouts in Professors & Scholars and Fun Stuff with horizontal scrolling cards
- add reusable scrolling gallery styles that match the home page timeline treatment and include captions for each Fun Stuff image

## Testing
- not run (HTML/CSS changes)


------
https://chatgpt.com/codex/tasks/task_e_68f96ba448b0832ebfc0e78b60ae808d