### PR TITLE
Increase gallery figure and caption size

### DIFF
--- a/css/archive.css
+++ b/css/archive.css
@@ -137,14 +137,14 @@ hr{
 
 .scrolling-card img {
         width: 100%;
-        height: 160px;
+        height: 240px;
         object-fit: cover;
         display: block;
 }
 
 .scrolling-caption {
         padding: 12px 14px 16px;
-        font-size: 1.3rem;
+        font-size: 1.95rem;
         line-height: 1.4;
         color: #333333;
 }
@@ -173,6 +173,6 @@ hr{
         }
 
         .scrolling-card img {
-                height: 140px;
+                height: 210px;
         }
 }


### PR DESCRIPTION
## Summary
- increase the scrolling gallery image heights by 1.5x
- enlarge the figure caption font size to match the new media scale

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f97a810074832eaedfa30c6e72e93a