### PR TITLE
Adjust scrolling gallery card dimensions

### DIFF
--- a/css/archive.css
+++ b/css/archive.css
@@ -117,7 +117,7 @@ hr{
         display: flex;
         flex-direction: column;
         text-align: center;
-        flex: 0 0 220px;
+        flex: 0 0 330px;
         scroll-snap-align: start;
         transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
@@ -137,7 +137,7 @@ hr{
 
 .scrolling-card img {
         width: 100%;
-        height: 240px;
+        height: 360px;
         object-fit: cover;
         display: block;
 }
@@ -155,7 +155,7 @@ hr{
         justify-content: center;
         flex-wrap: wrap;
         gap: 8px;
-        font-size: 1.2rem;
+        font-size: 1.8rem;
 }
 
 .scrolling-links a {
@@ -169,10 +169,10 @@ hr{
 
 @media (max-width: 480px) {
         .scrolling-card {
-                flex-basis: 180px;
+                flex-basis: 270px;
         }
 
         .scrolling-card img {
-                height: 210px;
+                height: 315px;
         }
 }


### PR DESCRIPTION
## Summary
- increase the scrolling card flex-basis to enlarge each gallery card
- scale gallery images and link text to maintain proportions at the larger size, including on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f97e10495c832e92e619d894fb348f