### PR TITLE
Triple scrolling caption font size

### DIFF
--- a/css/archive.css
+++ b/css/archive.css
@@ -144,7 +144,7 @@ hr{
 
 .scrolling-caption {
         padding: 12px 14px 16px;
-        font-size: 1.95rem;
+        font-size: 5.85rem;
         line-height: 1.4;
         color: #333333;
 }


### PR DESCRIPTION
## Summary
- triple the font size used for scrolling gallery captions to make the text significantly larger

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f9800f1dc4832e80e3ac75f68af571