### PR TITLE
Emphasize American football alt text in gallery

### DIFF
--- a/css/archive.css
+++ b/css/archive.css
@@ -158,6 +158,12 @@ hr{
         font-size: 1.2rem;
 }
 
+.scrolling-links.alt-text-large {
+        font-size: 3.6rem;
+        font-weight: 600;
+        text-align: center;
+}
+
 .scrolling-links a {
         color: #1a4d8f;
 }

--- a/gallery.html
+++ b/gallery.html
@@ -269,8 +269,9 @@
     <article class="scrolling-card">
       <figure>
 		  <div class="scrolling-links">
-        	<img src="/assets/img/afb2.JPG" alt="American football" loading="lazy">
-		  </div>
+                <img src="/assets/img/afb2.JPG" alt="American football" loading="lazy">
+                  </div>
+                  <div class="scrolling-links alt-text-large">American football</div>
       </figure>
     </article>
     <article class="scrolling-card">


### PR DESCRIPTION
## Summary
- add a reusable style for enlarged alternate text callouts in the gallery
- surface an "American football" caption beneath the relevant gallery image using the larger style

## Testing
- no tests were run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68f982c351e8832ea358cc28f66ea02c