### PR TITLE
Add Dislocations 2025 highlight and update course announcement

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
 </li>
 <li><p><font color="black">I am interested in solving problems in mechanics of materials from atomistic to continuum scales. My research interests are combining computational mechanics, materials theory, scientific machine learning, and inverse optimization for structural and materials modeling and design, with potential impact on energy, biotechnology, and advanced manufacturing.</p>
 </li>
-<li><p><font color="black">I TA'd <a target="_blank" rel="noopener" href="https://explorecourses.stanford.edu/search?q=ME335A&view=catalog&filter-coursestatus-Active=on&academicYear=20242025">Finite Element Analysis</a>, here are some <a target="_blank" rel="noopener" href="/file/ProbSess_FEA.pdf">Problem Session notes</a> that could be of help. Here is a <a target="_blank" rel="noopener" href="/file/FEA_Teach/FEARev.pdf">short intro</a> if you are interested in taking the course.</p>
+<li><p><font color="black"><span style="background-color: yellow;">Ad:</span> Please consider taking <a target="_blank" rel="noopener" href="https://explorecourses.stanford.edu/search?view=catalog&filter-coursestatus-Active=on&q=ME340">Elasticity &amp; Inelasticity (ME340)</a>, where I will be the TA. You'll learn core ideas in solid mechanics, elasticity, fracture, fatigue, and an introduction to plasticity. Previously, I TA'd <a target="_blank" rel="noopener" href="https://explorecourses.stanford.edu/search?q=ME335A&view=catalog&filter-coursestatus-Active=on&academicYear=20242025">Finite Element Analysis</a>; here are some <a target="_blank" rel="noopener" href="/file/ProbSess_FEA.pdf">Problem Session notes</a> and a <a target="_blank" rel="noopener" href="/file/FEA_Teach/FEARev.pdf">short intro</a> that might help.</p>
 </li>
 
 <hr class="bg_click">
@@ -192,13 +192,22 @@
         <p>Had an amazing time interning at <a href="https://www.merl.com/">MERL</a> working on ML and energy systems.</p>
       </div>
     </article>
-	<article class="timeline-card">
+    <article class="timeline-card">
       <div class="timeline-image">
         <img src="https://compfest.berkeley.edu/wp-content/uploads/2025/02/compfest2025_2-2048x1234.jpeg" alt="CompFest 2025 presentation" loading="lazy">
       </div>
       <div class="timeline-content">
         <p class="timeline-year">2025</p>
         <p>We <a href="https://compfest.berkeley.edu/presentations/">presented</a> our recent work on a new theory of dislocation link statistics in strain hardening at <a href="https://compfest.berkeley.edu/">CompFest 2025</a> at Berkeley.</p>
+      </div>
+    </article>
+    <article class="timeline-card">
+      <div class="timeline-image">
+        <img src="/assets/img/Dislocations2025.JPG" alt="Dislocations 2025 Best Poster" loading="lazy">
+      </div>
+      <div class="timeline-content">
+        <p class="timeline-year">2025</p>
+        <p>Honored to receive the Best Poster Award at the <a href="https://www.coe.miami.edu/events/dislocations-conference/index.html">Dislocations 2025</a> conference.</p>
       </div>
     </article>
     <article class="timeline-card">


### PR DESCRIPTION
## Summary
- add Dislocations 2025 Best Poster highlight with new timeline image
- refresh course advertisement bullet for Elasticity & Inelasticity with clearer details

## Testing
- python -m http.server 4000 (manual preview)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692895dd4e34832e92f743f53532b612)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new Dislocations 2025 Best Poster timeline highlight and updates the ME340 course announcement with clearer details and links.
> 
> - **Homepage content (`index.html`)**:
>   - **Timeline**: Add new 2025 card highlighting Dislocations 2025 Best Poster with image and link.
>   - **Course announcement**: Replace prior TA note with an ME340 Elasticity & Inelasticity ad, clarifying topics and retaining FEA notes/intro links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96bf4aa0a650a78d231bad990a6878dec5cbcf37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->