### PR TITLE
Refine Dislocations 2025 highlight text

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
 </li>
 <li><p><font color="black">I am interested in solving problems in mechanics of materials from atomistic to continuum scales. My research interests are combining computational mechanics, materials theory, scientific machine learning, and inverse optimization for structural and materials modeling and design, with potential impact on energy, biotechnology, and advanced manufacturing.</p>
 </li>
-<li><p><font color="black">I TA'd <a target="_blank" rel="noopener" href="https://explorecourses.stanford.edu/search?q=ME335A&view=catalog&filter-coursestatus-Active=on&academicYear=20242025">Finite Element Analysis</a>, here are some <a target="_blank" rel="noopener" href="/file/ProbSess_FEA.pdf">Problem Session notes</a> that could be of help. Here is a <a target="_blank" rel="noopener" href="/file/FEA_Teach/FEARev.pdf">short intro</a> if you are interested in taking the course.</p>
+<li><p><font color="black"><span style="background-color: yellow;">Ad:</span> Please consider taking <a target="_blank" rel="noopener" href="https://explorecourses.stanford.edu/search?view=catalog&filter-coursestatus-Active=on&q=ME340">Elasticity &amp; Inelasticity (ME340)</a>, where I will be the TA. You'll learn core ideas in solid mechanics, elasticity, fracture, fatigue, and an introduction to plasticity. Previously, I TA'd <a target="_blank" rel="noopener" href="https://explorecourses.stanford.edu/search?q=ME335A&view=catalog&filter-coursestatus-Active=on&academicYear=20242025">Finite Element Analysis</a>; here are some <a target="_blank" rel="noopener" href="/file/ProbSess_FEA.pdf">Problem Session notes</a> and a <a target="_blank" rel="noopener" href="/file/FEA_Teach/FEARev.pdf">short intro</a> that might help.</p>
 </li>
 
 <hr class="bg_click">
@@ -185,6 +185,15 @@
   <div class="timeline-scroll">
     <article class="timeline-card">
       <div class="timeline-image">
+        <img src="/assets/img/Dislocations2025.JPG" alt="Dislocations 2025 Best Poster Award" loading="lazy">
+      </div>
+      <div class="timeline-content">
+        <p class="timeline-year">2025</p>
+        <p>Honored to receive the Best Poster Award for our dislocation link statistics poster at the <a href="https://www.coe.miami.edu/events/dislocations-conference/index.html">Dislocations 2025</a> conference.</p>
+      </div>
+    </article>
+    <article class="timeline-card">
+      <div class="timeline-image">
         <img src="/assets/img/merl_intern.jpg" alt="MERL internship" loading="lazy">
       </div>
       <div class="timeline-content">
@@ -192,7 +201,7 @@
         <p>Had an amazing time interning at <a href="https://www.merl.com/">MERL</a> working on ML and energy systems.</p>
       </div>
     </article>
-	<article class="timeline-card">
+    <article class="timeline-card">
       <div class="timeline-image">
         <img src="https://compfest.berkeley.edu/wp-content/uploads/2025/02/compfest2025_2-2048x1234.jpeg" alt="CompFest 2025 presentation" loading="lazy">
       </div>


### PR DESCRIPTION
## Summary
- refine the Dislocations 2025 timeline card alt text and description of the Best Poster award
- preview the homepage to verify the new highlight remains first in the recent highlights carousel

## Testing
- python -m http.server 4000

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692895dd4e34832e92f743f53532b612)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new Dislocations 2025 Best Poster Award timeline card and updates the teaching blurb to promote ME340 while retaining FEA resources.
> 
> - **Homepage (`index.html`)**:
>   - **Timeline**: Add new 2025 card with image and copy for Dislocations 2025 Best Poster Award at the top of Recent highlights.
>   - **About/Intro list**: Replace FEA-only TA note with ME340 course promotion (TA), keeping links to FEA problem session notes and intro.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42186497c3ef1d6e9e1bfa6e32dae0f87cbed26d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->